### PR TITLE
Initial dev version of inner product intrinsic.

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3996,7 +3996,69 @@ void StubGenerator::generate_initial_stubs() {
   generate_libm_stubs();
 
   StubRoutines::_fmod = generate_libmFmod(); // from stubGenerator_x86_64_fmod.cpp
+
+  // KDY
+  StubRoutines::_kdy_innerProduct = generate_kdy_inner_product();
+  // KDY
 }
+
+// KDY
+address StubGenerator::generate_kdy_inner_product() {
+  // It will be guaranteed that two float arrays having identical length which is a multiple of 8.
+  // Ex: float[] vec1, float[] vec2 where len(vec1) == len(vec2) and len(vec1) % 8 == 0
+
+  StubCodeMark mark(this, "StubRoutines", "kdyIP");
+  address start = __ pc();
+
+  const Register vec1        = c_rarg0;  // vec1
+  const Register vec2        = c_rarg1;  // vec2
+  const Register dimension   = c_rarg2;  // dimension
+  const auto ymm0 = xmm0;
+  const auto ymm1 = xmm1;
+  const auto ymm2 = xmm2;
+
+  Label L_loop, L_remainder, L_rem_loop, L_reduce;
+
+  __ enter(); // required for proper stackwalking of RuntimeStub frame
+
+  // Set up registers
+  __ vxorps(ymm0, ymm0, ymm0, Assembler::AVX_256bit);
+  __ shrl(dimension, 3);
+
+  // Start loop
+  __ bind(L_loop);
+  __ vmovups(ymm1, Address(vec1, 0), Assembler::AVX_256bit);
+  __ vmovups(ymm2, Address(vec2, 0), Assembler::AVX_256bit);
+  __ vfmadd231ps(ymm0, ymm1, ymm2, Assembler::AVX_256bit);
+
+  // Inc pointers
+  __ addq(vec1, 32);
+  __ addq(vec2, 32);
+  __ decq(dimension);
+  __ testl(dimension, 0);
+  __ jcc(Assembler::notEqual, L_loop);
+
+  // Reduce
+  __ vextractf128(xmm1, ymm0, 1);
+  __ addps(xmm0, xmm1);  // xmm0 have four values sumed up.
+
+  __ movaps(xmm1, xmm0);  // xmm0 = [v0, v1, v2, v3]
+  __ shufps(xmm1, xmm1, 0xF4);  // xmm1 = [DC, DC, v0, v1]
+  __ addps(xmm0, xmm1);  // xmm0 = [DC, DC, v0 + v2, v1 + v3]
+
+  __ movaps(xmm1, xmm0);  // duplicate xmm0 to xmm1
+  __ psllq(xmm1, 32);  // xmm1 = [DC, DC, DC, v0 + v2]
+  __ addps(xmm0, xmm1);  // xmm0 = [DC, DC, DC, v0 + v1 + v2 + v3]
+
+  __ shufps(xmm0, xmm0, 0xFF);  // xmm0 = [v0 + v1 + v2 + v3, ...]
+
+
+  __ leave();
+  __ ret(0);
+
+  return start;
+}
+// KDY
 
 void StubGenerator::generate_continuation_stubs() {
   // Continuation stubs:

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -516,6 +516,10 @@ class StubGenerator: public StubCodeGenerator {
   address generate_libmLog10();
   address generate_libmFmod();
 
+  // KDY
+  address generate_kdy_inner_product();
+  // KDY
+
   // Shared constants
   static address ZERO;
   static address NEG_ZERO;

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -195,6 +195,13 @@ class methodHandle;
   do_intrinsic(_dsignum,                  java_lang_Math,         signum_name,        double_double_signature,   F_S)   \
   do_intrinsic(_fsignum,                  java_lang_Math,         signum_name,        float_float_signature,     F_S)   \
                                                                                                                         \
+  /* KDY */                                                                                                             \
+  do_class(_k_java_lang_Kdy, "java/lang/Kdy")                                                                           \
+  do_name(_k_inner_product_name, "innerProduct")                                                                        \
+  do_signature(_k_fa_fa_signature, "([F[F)F")                                                                           \
+  do_intrinsic(_k_inner_product, _k_java_lang_Kdy, _k_inner_product_name, _k_fa_fa_signature, F_S)                      \
+  /* KDY */                                                                                                             \
+                                                                                                                        \
   /* StrictMath intrinsics, similar to what we have in Math. */                                                         \
   do_intrinsic(_min_strict,               java_lang_StrictMath,   min_name,           int2_int_signature,        F_S)   \
   do_intrinsic(_max_strict,               java_lang_StrictMath,   max_name,           int2_int_signature,        F_S)   \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -788,6 +788,7 @@ bool C2Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_Preconditions_checkIndex:
   case vmIntrinsics::_Preconditions_checkLongIndex:
   case vmIntrinsics::_getObjectSize:
+  case vmIntrinsics::_k_inner_product:
     break;
   case vmIntrinsics::_VectorCompressExpand:
   case vmIntrinsics::_VectorUnaryOp:

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -753,6 +753,9 @@ bool LibraryCallKit::try_to_inline(int predicate) {
   case vmIntrinsics::_blackhole:
     return inline_blackhole();
 
+    case vmIntrinsics::_k_inner_product:
+      return inline_k_inner_product(intrinsic_id());
+
   default:
     // If you get here, it may be that someone has added a new intrinsic
     // to the list in vmIntrinsics.hpp without implementing it here.
@@ -765,6 +768,33 @@ bool LibraryCallKit::try_to_inline(int predicate) {
     return false;
   }
 }
+
+// KDY
+bool LibraryCallKit::inline_k_inner_product(vmIntrinsics::ID id) {
+  Node* vec1 = argument(0);
+  Node* vec2 = argument(0);
+
+  Node* len1 = load_array_length(vec1);
+
+  auto stubAddr = StubRoutines::kdy_innerProduct();
+  const auto stubName = "kdy_innerProduct";
+
+  Node* call = make_runtime_call(RC_LEAF,
+                                 OptoRuntime::kdy_innerProduct_Type(),
+                                 stubAddr,
+                                 stubName,
+                                 TypePtr::BOTTOM,
+                                 vec1,
+                                 vec2,
+                                 len1);
+
+  Node* result = _gvn.transform(new ProjNode(call, TypeFunc::Parms));
+  set_result(result);
+
+  return true;
+}
+// KDY
+
 
 Node* LibraryCallKit::try_to_predicate(int predicate) {
   if (!jvms()->has_method()) {

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -342,6 +342,10 @@ class LibraryCallKit : public GraphKit {
 
   bool inline_continuation_do_yield();
 
+  // KDY
+  bool inline_k_inner_product(vmIntrinsics::ID id);
+  // KDY
+
   // Vector API support
   bool inline_vector_nary_operation(int n);
   bool inline_vector_frombits_coerced();

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -821,6 +821,22 @@ const TypeFunc* OptoRuntime::fast_arraycopy_Type() {
   return make_arraycopy_Type(ac_fast);
 }
 
+const TypeFunc* OptoRuntime::kdy_innerProduct_Type() {
+  // Input
+  const Type** fields = TypeTuple::fields(3);
+  fields[TypeFunc::Parms+0] = TypePtr::NOTNULL;
+  fields[TypeFunc::Parms+1] = TypePtr::NOTNULL;
+  fields[TypeFunc::Parms+2] = Type::FLOAT;
+  const TypeTuple *domain = TypeTuple::make(TypeFunc::Parms+3, fields);
+
+  // Output
+  fields = TypeTuple::fields(1);
+  fields[TypeFunc::Parms+0] = Type::FLOAT;
+  const TypeTuple *range = TypeTuple::make(TypeFunc::Parms+0, fields);
+
+  return TypeFunc::make(domain, range);
+}
+
 const TypeFunc* OptoRuntime::checkcast_arraycopy_Type() {
   // An extension of fast_arraycopy_Type which adds type checking.
   return make_arraycopy_Type(ac_checkcast);

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -268,6 +268,10 @@ private:
 
   static const TypeFunc* array_fill_Type();
 
+  // TMP
+  static const TypeFunc* kdy_innerProduct_Type();
+  // TMP
+
   static const TypeFunc* array_sort_Type();
   static const TypeFunc* array_partition_Type();
   static const TypeFunc* aescrypt_block_Type();

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -170,6 +170,10 @@ address StubRoutines::_dlibm_reduce_pi04l = nullptr;
 address StubRoutines::_dlibm_tan_cot_huge = nullptr;
 address StubRoutines::_dtan = nullptr;
 
+// KDY
+address StubRoutines::_kdy_innerProduct = nullptr;
+// KDY
+
 address StubRoutines::_f2hf = nullptr;
 address StubRoutines::_hf2f = nullptr;
 

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -262,6 +262,10 @@ class StubRoutines: AllStatic {
   static address _cont_returnBarrier;
   static address _cont_returnBarrierExc;
 
+  // KDY
+  static address _kdy_innerProduct;
+  // KDY
+
   JFR_ONLY(static RuntimeStub* _jfr_write_checkpoint_stub;)
   JFR_ONLY(static address _jfr_write_checkpoint;)
   JFR_ONLY(static RuntimeStub* _jfr_return_lease_stub;)
@@ -443,6 +447,10 @@ class StubRoutines: AllStatic {
   static address dlibm_sin_cos_huge()  { return _dlibm_sin_cos_huge; }
   static address dlibm_tan_cot_huge()  { return _dlibm_tan_cot_huge; }
   static address dtan()                { return _dtan; }
+
+  // KDY
+  static address kdy_innerProduct()                { return _kdy_innerProduct; }
+  // KDY
 
   // These are versions of the java.lang.Float::floatToFloat16() and float16ToFloat()
   // methods which perform the same operations as the intrinsic version.

--- a/src/java.base/share/classes/java/lang/Kdy.java
+++ b/src/java.base/share/classes/java/lang/Kdy.java
@@ -1,0 +1,27 @@
+import jdk.internal.vm.annotation.IntrinsicCandidate;
+
+/**
+ * Dummy comment
+ */
+public final class Kdy {
+    /**
+     * Dummy comment
+     */
+    private Kdy() {
+    }
+
+    /**
+     * Dummy conmment
+     * @param vec1 vec1
+     * @param vec2 vec2
+     * @return result
+     */
+    @IntrinsicCandidate
+    public static float innerProduct(float[] vec1, float[] vec2) {
+      float ret = 0;
+      for (int i = 0 ; i < vec1.length ; ++i) {
+        ret += vec1[i] * vec2[i];
+      }
+      return ret;
+    }
+}


### PR DESCRIPTION
## Description
This PR tries to add a custom intrinsic method into JDK doing an inner product to two float vectors.
The idea is to have C2 compiler to be able to replace inner product method body with entire AVX2 optimized commands to improve performance of similarity calculation. This is one of approaches being explored at the moment where using JNI, FFM to offload the calculation to C++ layer. However, if we could find a way to delegate this heavy lift to C2 compiler in JVM, then we won't need C++. We can directly optimize at assembly level. (we're gonna use Intel intrinsic anyway, no different playing assembly code at all). Furthermore, this will give a chance to optimize fp16 array case which is not yet supported even in Panama. Or humming distance where it needs bit level manipulation or handling byte array etc.

This initial version assumes that only applies to a vector whose length is a multiply of 8 for simplicity. ex: 128.
